### PR TITLE
Add null check for $project in the template/starred-projects.php

### DIFF
--- a/Template/dashboard/starred-projects.php
+++ b/Template/dashboard/starred-projects.php
@@ -5,7 +5,10 @@
             <div class="table-list-header-count"><?= t('Starred projects') ?></div>
             <div class="table-list-header-menu">&nbsp;</div>
         </div>
-        <?php foreach ($starredProjects as $project): ?>
+        <?php foreach ($starredProjects as $project): 
+              if($project == null)
+			     continue;
+        ?>
             <div class="table-list-row table-border-left">
                 <div>
                     <?php if ($this->user->hasProjectAccess('ProjectViewController', 'show', $project['id'])): ?>


### PR DESCRIPTION
This fixes an issue where if a starred project is deleted the dashboard "starred projects" listings shows error on the frontend.